### PR TITLE
Add scripts to publish package cgmodsel to the python package index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 *.pdf
 *.synctex
 *.tcp
+
+venv
+venv-pypi

--- a/bash/distribute_pypi.bash
+++ b/bash/distribute_pypi.bash
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# This script builds a this module as a package and uploads it to pypi.org
+# Provide your PYPI-credentials in ~/.pypirc
+
+# https://packaging.python.org/tutorials/packaging-projects/
+
+# Create venv
+python -m venv ./venv-pypi
+source venv-pypi/bin/activate
+
+# Install necessary packs
+python -m pip install --upgrade pip
+python -m pip install --upgrade setuptools wheel twine
+
+# Build dist
+python setup.py install sdist bdist_wheel
+
+#Upload to testpypi
+python -m twine upload --repository pypi dist/*
+
+# Clean
+deactivate
+rm -rf venv-pypi
+rm -rf dist/*

--- a/bash/distribute_testpypi.bash
+++ b/bash/distribute_testpypi.bash
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# This script builds a this module as a package and uploads it to test.pypi.org
+# Provide your TESTPYPI-credentials in ~/.pypirc
+
+# https://packaging.python.org/tutorials/packaging-projects/
+
+# Create venv
+python3.7 -m venv ./venv-pypi
+source venv-pypi/bin/activate
+
+# Install necessary packs
+python -m pip install --upgrade pip
+python -m pip install --upgrade setuptools wheel twine
+
+# Build dist
+python setup.py install sdist bdist_wheel
+
+#Upload to testpypi
+python -m twine upload --repository testpypi dist/*
+
+# Clean
+deactivate
+rm -rf venv-pypi
+rm -rf dist/*


### PR DESCRIPTION
To be able to publish lumen as a package on pypi we need cgmodsel to be installable via pip.
This branch adds two scripts to build this package and to distribute it to pypi.org and test.pypi.org and adds directories for virtual environments to ".gitignore".